### PR TITLE
Wildcards Issue

### DIFF
--- a/EventEmitter.js
+++ b/EventEmitter.js
@@ -22,7 +22,7 @@ function EventEmitter() {
  * @return {String} RegExp pattern
  */
 EventEmitter.prototype._convertNameToRegExp = function(name) {
-	return name.replace(/\./g, '\\.').replace(/\*\./g, '[\\w\\-]+\\.').replace(/\*$/gi, '.+');
+	return name.replace(/\./g, '\\.').replace(/\*\\\./g, '[\\w\\-]+\\.').replace(/\*$/gi, '.+');
 };
 
 /**


### PR DESCRIPTION
Noticed this small oversight today. Some wildcards aren't detected, e.g.,

```
foo.*.bar
```

Fixed it.
