### PR TITLE
Add aliases for some functions

### DIFF
--- a/EventEmitter.js
+++ b/EventEmitter.js
@@ -95,6 +95,7 @@
         // Return the instance of EventEmitter to allow chaining
         return this;
     };
+    proto.on = proto.addListener;
 
     /**
      * Removes a listener function from the specified event.
@@ -123,6 +124,7 @@
         // Return the instance of EventEmitter to allow chaining
         return this;
     };
+    proto.off = proto.removeListener;
 
     /**
      * Adds listeners in bulk using the manipulateListeners method.
@@ -259,6 +261,7 @@
         // Return the instance of EventEmitter to allow chaining
         return this;
     };
+    proto.trigger = proto.emitEvent;
 
     // Expose the class either via AMD or the global object
     if(typeof define === 'function' && define.amd) {


### PR DESCRIPTION
This mirrors the [Backbonejs events API](http://backbonejs.org/#Events) and to a lesser extent the
[Nodejs events API](http://nodejs.org/docs/latest/api/events.html#events_emitter_on_event_listener).
- `on()` = `addListener()`
- `off()` = `removeListener()`
- `trigger()` = `emitEvent()`

We use use EventEmitter in more places than Backbone, so it's nice to be able to use the same API between objects that mixin `Backbone.Events` and those that mixin `EventEmitter`.
