### PR TITLE
remove EventEmitter.min.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,8 +3,7 @@
 	"description": "Event based JavaScript for the browser",
 	"version": "4.1.0",
 	"main": [
-		"./EventEmitter.js",
-		"./EventEmitter.min.js"
+		"./EventEmitter.js"
 	],
 	"author": {
 		"name": "Oliver Caldwell",


### PR DESCRIPTION
In the [working bower.json spec](https://docs.google.com/a/twitter.com/document/d/1APq7oA9tNao1UYWyOm8dKqlRP2blVkROYLZ2fLIjtWc) we are moving to remove minified files from `main`.

This is a good move. For example, in my [build process for Packery](https://github.com/metafizzy/packery-docs/blob/master/tasks/bower-list-map.js#L29-L33) I have to manually remove `EventEmitter.min.js`, otherwise it appears twice in my concatenated/minified file.
