### PR TITLE
moved to non-wrapped use of Array.indexOf when available

### DIFF
--- a/EventEmitter.js
+++ b/EventEmitter.js
@@ -368,7 +368,11 @@
 			return EventEmitter;
 		});
 	}
-	else {
-		exports.EventEmitter = EventEmitter;
+	else if (typeof module !== 'undefined' && module.exports){
+		// CommonJS module is defined
+		module.exports = EventEmitter;
 	}
-}(this));
+	else {
+		this.EventEmitter = EventEmitter;
+	}
+}.call(this));


### PR DESCRIPTION
swapped order of args to support `Array.indexOf(haystack, needle)`, deprecated need for `indexOfListener` when native is there.
