### PR TITLE
little refactor - use listener.listener

### DIFF
--- a/EventEmitter.js
+++ b/EventEmitter.js
@@ -355,7 +355,7 @@
 					listener = listeners[key][i];
 					response = listener.listener.apply(this, args || []);
 					if (response === this._getOnceReturnValue() || listener.once === true) {
-						this.removeListener(evt, listeners[key][i].listener);
+						this.removeListener(evt, listener.listener);
 					}
 				}
 			}


### PR DESCRIPTION
I was running into a bug with using `return true`. Bizarrely, `listener = listeners[key][i];` returned a listener, but within the conditional `listeners[key][i]` was undefined. changing it to `listener.listener` resolve the matter.

My test case looked something like

``` js
ee.addListener('baz', function() {
  count++;
  ee.addListener('baz', function() {
    count++;
  });
  return true;
});
```

I wasn't able to reproduce the error with a test case, so this might not even be worth it. But I felt like I should at least document it.
