### PR TITLE
EventEmitter: Use the 'exports' variable as global

### DIFF
--- a/EventEmitter.js
+++ b/EventEmitter.js
@@ -467,6 +467,6 @@
 		module.exports = EventEmitter;
 	}
 	else {
-		this.EventEmitter = EventEmitter;
+		exports.EventEmitter = EventEmitter;
 	}
 }.call(this));


### PR DESCRIPTION
Follows-up aba18feb4abb5a2d90947b0d404dc50783593462.

The local `exports` variable is set to `this`. Not sure why it wasn't being used.
