### PR TITLE
Allow removal of another listener from within a listener

### DIFF
--- a/EventEmitter.js
+++ b/EventEmitter.js
@@ -358,20 +358,22 @@
      * @return {Object} Current instance of EventEmitter for chaining.
      */
     proto.emitEvent = function emitEvent(evt, args) {
-        var listeners = this.getListenersAsObject(evt);
+        var listenersMap = this.getListenersAsObject(evt);
+        var listeners;
         var listener;
         var i;
         var key;
         var response;
 
-        for (key in listeners) {
-            if (listeners.hasOwnProperty(key)) {
-                i = listeners[key].length;
+        for (key in listenersMap) {
+            if (listenersMap.hasOwnProperty(key)) {
+                listeners = listenersMap[key].slice(0);
+                i = listeners.length;
 
                 while (i--) {
                     // If the listener returns true then it shall be removed from the event
                     // The function is executed either with a basic call or an apply if there is an args array
-                    listener = listeners[key][i];
+                    listener = listeners[i];
 
                     if (listener.once === true) {
                         this.removeListener(evt, listener.listener);

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -466,6 +466,23 @@
             assert.strictEqual(flattenCheck(check), '1,2,3,4');
         });
 
+        test('can remove another listener from within a listener', function() {
+            var check = [];
+            var toRemove = function() { check.push('1'); };
+
+            ee.addListener('baz', toRemove);
+            ee.addListener('baz', function() {
+                check.push(2);
+                ee.removeListener('baz', toRemove);
+            });
+            ee.addListener('baz', function() { check.push(3); });
+
+            ee.emitEvent('baz');
+            ee.emitEvent('baz');
+
+            assert.strictEqual(flattenCheck(check), '1,2,2,3,3');
+        });
+
         test('executes multiple listeners and removes those that return true', function() {
             var check = [];
 


### PR DESCRIPTION
This PR provides a test case and a solution for a subtle issue I ran into.

The issue is illustrated in the test case (7c69b6b), but can be summarized as follows:

Given an event emitter `ee` with a listener `a` for event `'someEvent'`:
```javascript
function a = { /* ... */ };
ee.addListener('someEvent', a);
```

And another listener `b` for the same event, which removes `a` as a listener for that event:
```javascript
function b = { ee.removeListener('someEvent', a); };
ee.addListener('someEvent', b);
```

It should be the case that `a` is no longer a listener for the *next* emitting of `'someEvent'`, and that both `a` and `b` will hear the currently emitting `'someEvent'` exactly *once* each. However, because the listeners list is changed by the handler *while the event is still being handled*, one of two actual behaviors may occur:

1. Either the last handler to be applied gets re-applied because the list length has shrunk by the same amount as the [decrement][1] of the iteration index (`i`)
2. or, if more than one listener is removed by a handler, [this line][2] will throw with something like `cannot get property once of undefined`, as the iteration index (`i`) is now beyond the bounds of the [listener list][3].

The proposed fix (52f7c17) simply clones the list of listeners to guarantee that it can't change during an emit event.

Another solution might be to clone the listeners in [`getListeners`][4], though I don't know what implications that might have for the wider system.

[1]: https://github.com/Wolfy87/EventEmitter/blob/develop/EventEmitter.js#L371
[2]: https://github.com/Wolfy87/EventEmitter/blob/develop/EventEmitter.js#L376
[3]: https://github.com/Wolfy87/EventEmitter/blob/develop/EventEmitter.js#L374
[4]: https://github.com/Wolfy87/EventEmitter/blob/develop/EventEmitter.js#L65-L85