### PR TITLE
bower.json nitpick: Use standard 'license' attribute

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,12 +9,7 @@
         "name": "Oliver Caldwell",
         "web": "http://oli.me.uk/"
     },
-    "licenses": [
-        {
-            "type": "Unlicense",
-            "url": "http://unlicense.org/"
-        }
-    ],
+    "license": "Unlicense",
     "keywords": [
         "events",
         "structure"


### PR DESCRIPTION
From the bower/bower.json-spec readme:

*Recommended*
Type: `String` or `Array` of `String`

[SPDX license identifier](https://spdx.org/licenses/) or path/url to a license.