### PR TITLE
Fixes invalid token on TS definition file

### DIFF
--- a/EventEmitter.d.ts
+++ b/EventEmitter.d.ts
@@ -444,7 +444,7 @@ declare namespace Wolfy87EventEmitter {
          * @param {Array} [args] Optional array of arguments to be passed to each listener.
          * @return {EventEmitter} Current instance of EventEmitter for chaining.
          */
-        emitEvent(event: RegExp, args: any[] = []): EventEmitter;
+        emitEvent(event: RegExp, args?: any[]): EventEmitter;
 
         /**
          * Emits an event of your choice.


### PR DESCRIPTION
There is an invalid token on the TS definition file.
Since version v5.2.7 the TS compiler started to throw the following exception:

![image](https://user-images.githubusercontent.com/4458855/64468272-918d1880-d0d7-11e9-9eb9-e530776113e5.png)

