### PR TITLE
Fix type definition of emitEvent method

### DIFF
--- a/EventEmitter.d.ts
+++ b/EventEmitter.d.ts
@@ -431,7 +431,7 @@ declare namespace Wolfy87EventEmitter {
          * @param {Array} [args] Optional array of arguments to be passed to each listener.
          * @return {EventEmitter} Current instance of EventEmitter for chaining.
          */
-        emitEvent(event: string, args: any[]): EventEmitter;
+        emitEvent(event: string, args?: any[]): EventEmitter;
 
         /**
          * Emits to all events that match the regular expression passed


### PR DESCRIPTION
Hi! First of all thank you for this library!

While transition of one of my project to TS I just noticed `emitEvent` has an incorrect type definition.`args` is an optional arg.
There was nearly identical fix (https://github.com/Olical/EventEmitter/pull/153) but since it was focused on something slightly different it unfortunately missed fixing other version of `emitEvent` method.